### PR TITLE
Only attempt to index PDFs when they're there

### DIFF
--- a/api/web/web.go
+++ b/api/web/web.go
@@ -171,13 +171,16 @@ func Listen(port int) {
 	app.HTTPErrorHandler = customHTTPErrorHandler
 
 	if _, err := os.Stat(filepath.Join(exPath, "content", "pdfindex.dat")); err != nil {
-		log.Info().Msg("Generating PDF Index. This may take some time.")
 		pdfPath, err := utils.GetPDFPath()
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to get pdf path")
 			return
 		}
-		pdfs.GenerateIndex(pdfPath)
+		// If we can't find the path for PDFs, we can't generate the index
+		if _, err := os.Stat(pdfPath); err == nil {
+			log.Info().Msg("Generating PDF Index. This may take some time.")
+			pdfs.GenerateIndex(pdfPath)
+		}
 	}
 
 	log.Fatal().Err(app.Start(fmt.Sprintf(":%d", port))).Int("port", port).Msg("Failed to listen")


### PR DESCRIPTION
This allows the version of the drive with PDFs to be used as the content-free version just by deleting the PDFs folder. With this change, there will be no error logged when the PDF folder doesn't exist.